### PR TITLE
hybrid reader some minor feature updates

### DIFF
--- a/cmd/ips/cmd_dump.go
+++ b/cmd/ips/cmd_dump.go
@@ -32,9 +32,10 @@ func init() {
 	dumpCmd.Flags().StringVarP(&lang, "lang", "", "", UsageLang)
 
 	// input & output
-	dumpCmd.Flags().StringVarP(&inputFile, "input-file", "i", "", UsageDPInputFile)
-	dumpCmd.Flags().StringVarP(&inputFormat, "input-format", "", "", UsageDPInputFormat)
+	dumpCmd.Flags().StringSliceVarP(&inputFile, "input-file", "i", nil, UsageDPInputFile)
+	dumpCmd.Flags().StringSliceVarP(&inputFormat, "input-format", "", nil, UsageDPInputFormat)
 	dumpCmd.Flags().StringVarP(&readerOption, "input-option", "", "", UsageReaderOption)
+	dumpCmd.Flags().StringVarP(&hybridMode, "hybrid-mode", "", "aggregation", UsageHybridMode)
 	dumpCmd.Flags().StringVarP(&outputFile, "output-file", "o", "", UsageDumpOutputFile)
 
 }
@@ -63,7 +64,7 @@ func Dump(cmd *cobra.Command, args []string) {
 	}
 
 	if len(inputFile) == 0 {
-		inputFile = args[0]
+		inputFile = []string{args[0]}
 	}
 
 	if err := manager.Pack(inputFormat, inputFile, plain.DBFormat, outputFile); err != nil {

--- a/cmd/ips/cmd_myip.go
+++ b/cmd/ips/cmd_myip.go
@@ -37,13 +37,14 @@ func init() {
 	myipCmd.Flags().StringVarP(&lang, "lang", "", "", UsageLang)
 
 	// database
-	myipCmd.Flags().StringVarP(&rootFile, "file", "i", "", UsageQueryFile)
-	myipCmd.Flags().StringVarP(&rootFormat, "format", "", "", UsageQueryFormat)
-	myipCmd.Flags().StringVarP(&rootIPv4File, "ipv4-file", "", "", UsageQueryIPv4File)
-	myipCmd.Flags().StringVarP(&rootIPv4Format, "ipv4-format", "", "", UsageQueryIPv4Format)
-	myipCmd.Flags().StringVarP(&rootIPv6File, "ipv6-file", "", "", UsageQueryIPv6File)
-	myipCmd.Flags().StringVarP(&rootIPv6Format, "ipv6-format", "", "", UsageQueryIPv6Format)
+	myipCmd.Flags().StringSliceVarP(&rootFile, "file", "i", nil, UsageQueryFile)
+	myipCmd.Flags().StringSliceVarP(&rootFormat, "format", "", nil, UsageQueryFormat)
+	myipCmd.Flags().StringSliceVarP(&rootIPv4File, "ipv4-file", "", nil, UsageQueryIPv4File)
+	myipCmd.Flags().StringSliceVarP(&rootIPv4Format, "ipv4-format", "", nil, UsageQueryIPv4Format)
+	myipCmd.Flags().StringSliceVarP(&rootIPv6File, "ipv6-file", "", nil, UsageQueryIPv6File)
+	myipCmd.Flags().StringSliceVarP(&rootIPv6Format, "ipv6-format", "", nil, UsageQueryIPv6Format)
 	myipCmd.Flags().StringVarP(&readerOption, "database-option", "", "", UsageReaderOption)
+	myipCmd.Flags().StringVarP(&hybridMode, "hybrid-mode", "", "aggregation", UsageHybridMode)
 
 	// output
 	myipCmd.Flags().StringVarP(&rootTextFormat, "text-format", "", "", UsageTextFormat)

--- a/cmd/ips/cmd_pack.go
+++ b/cmd/ips/cmd_pack.go
@@ -30,9 +30,10 @@ func init() {
 	packCmd.Flags().StringVarP(&lang, "lang", "", "", UsageLang)
 
 	// input & output
-	packCmd.Flags().StringVarP(&inputFile, "input-file", "i", "", UsageDPInputFile)
-	packCmd.Flags().StringVarP(&inputFormat, "input-format", "", "", UsageDPInputFormat)
+	packCmd.Flags().StringSliceVarP(&inputFile, "input-file", "i", nil, UsageDPInputFile)
+	packCmd.Flags().StringSliceVarP(&inputFormat, "input-format", "", nil, UsageDPInputFormat)
 	packCmd.Flags().StringVarP(&readerOption, "input-option", "", "", UsageReaderOption)
+	packCmd.Flags().StringVarP(&hybridMode, "hybrid-mode", "", "aggregation", UsageHybridMode)
 	packCmd.Flags().StringVarP(&outputFile, "output-file", "o", "", UsagePackOutputFile)
 	packCmd.Flags().StringVarP(&outputFormat, "output-format", "", "", UsagePackOutputFormat)
 	packCmd.Flags().StringVarP(&writerOption, "output-option", "", "", UsageWriterOption)

--- a/cmd/ips/cmd_server.go
+++ b/cmd/ips/cmd_server.go
@@ -32,13 +32,15 @@ func init() {
 	serverCmd.Flags().StringVarP(&lang, "lang", "", "", UsageLang)
 
 	// database
-	serverCmd.Flags().StringVarP(&rootFile, "file", "i", "", UsageQueryFile)
-	serverCmd.Flags().StringVarP(&rootFormat, "format", "", "", UsageQueryFormat)
-	serverCmd.Flags().StringVarP(&rootIPv4File, "ipv4-file", "", "", UsageQueryIPv4File)
-	serverCmd.Flags().StringVarP(&rootIPv4Format, "ipv4-format", "", "", UsageQueryIPv4Format)
-	serverCmd.Flags().StringVarP(&rootIPv6File, "ipv6-file", "", "", UsageQueryIPv6File)
-	serverCmd.Flags().StringVarP(&rootIPv6Format, "ipv6-format", "", "", UsageQueryIPv6Format)
+	serverCmd.Flags().StringSliceVarP(&rootFile, "file", "i", nil, UsageQueryFile)
+	serverCmd.Flags().StringSliceVarP(&rootFormat, "format", "", nil, UsageQueryFormat)
+	serverCmd.Flags().StringSliceVarP(&rootIPv4File, "ipv4-file", "", nil, UsageQueryIPv4File)
+	serverCmd.Flags().StringSliceVarP(&rootIPv4Format, "ipv4-format", "", nil, UsageQueryIPv4Format)
+	serverCmd.Flags().StringSliceVarP(&rootIPv6File, "ipv6-file", "", nil, UsageQueryIPv6File)
+	serverCmd.Flags().StringSliceVarP(&rootIPv6Format, "ipv6-format", "", nil, UsageQueryIPv6Format)
 	serverCmd.Flags().StringVarP(&readerOption, "database-option", "", "", UsageReaderOption)
+	serverCmd.Flags().StringVarP(&hybridMode, "hybrid-mode", "", "aggregation", UsageHybridMode)
+
 }
 
 var serverCmd = &cobra.Command{

--- a/cmd/ips/config.go
+++ b/cmd/ips/config.go
@@ -55,22 +55,25 @@ var (
 	// root command flags
 	// database
 	// rootFormat defines the format for database.
-	rootFormat string
+	rootFormat []string
 
 	// rootFile specifies the file path for database.
-	rootFile string
+	rootFile []string
 
 	// rootIPv4Format defines the format for IPv4 database.
-	rootIPv4Format string
+	rootIPv4Format []string
 
 	// rootIPv4File specifies the file path for IPv4 database.
-	rootIPv4File string
+	rootIPv4File []string
 
 	// rootIPv6Format defines the format for IPv6 database.
-	rootIPv6Format string
+	rootIPv6Format []string
 
 	// rootIPv6File specifies the file path for IPv6 database.
-	rootIPv6File string
+	rootIPv6File []string
+
+	// hybridMode specifies the operational mode of the HybridReader.
+	hybridMode string
 
 	// output
 	// rootTextFormat defines the format for text output.
@@ -97,10 +100,10 @@ var (
 	dpRewriterFiles string
 
 	// inputFile specifies the input file for dump and pack operations.
-	inputFile string
+	inputFile []string
 
 	// inputFormat specifies the input format for dump and pack operations.
-	inputFormat string
+	inputFormat []string
 
 	// outputFile specifies the output file for dump and pack operations.
 	outputFile string
@@ -178,6 +181,22 @@ func GetFlagConfig() *ips.Config {
 		if len(rootIPv6Format) != 0 {
 			conf.IPv6Format = rootIPv6Format
 		}
+	}
+
+	if len(conf.IPv4Format) == 0 {
+		conf.IPv4Format = make([]string, len(conf.IPv4File))
+	} else if len(conf.IPv4File) != len(conf.IPv4Format) {
+		log.Fatal("IPv4 file and format mismatch")
+	}
+
+	if len(conf.IPv6Format) == 0 {
+		conf.IPv6Format = make([]string, len(conf.IPv6File))
+	} else if len(conf.IPv6File) != len(conf.IPv6Format) {
+		log.Fatal("IPv6 file and format mismatch")
+	}
+
+	if len(hybridMode) != 0 {
+		conf.HybridMode = hybridMode
 	}
 
 	if len(rootTextFormat) != 0 {

--- a/cmd/ips/const.go
+++ b/cmd/ips/const.go
@@ -45,6 +45,7 @@ const (
 	UsagePackOutputFormat = "The format for the output IP database file."
 	UsageReaderOption     = "Additional options for the database reader, if applicable."
 	UsageWriterOption     = "Additional options for the database writer, if applicable."
+	UsageHybridMode       = "Sets mode for multi-IP source handling; 'comparison' to compare, 'aggregation' to merge data."
 
 	// Output Flags
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,6 +17,7 @@
     * [ipv4_format](#ipv4format)
     * [ipv6_file](#ipv6file)
     * [ipv6_format](#ipv6format)
+    * [hybrid_mode](#hybridmode)
     * [fields](#fields)
     * [use_db_fields](#usedbfields)
     * [rewrite_files](#rewritefiles)
@@ -167,6 +168,15 @@ IPS 提供了丰富的配置参数以适应不同的使用场景。以下是所�
 指定 IPv6 数据库文件的格式，字符串参数。
 
 当数据库文件后缀不足以确定文件格式时，用来指定 IPv6 数据库的格式。通常不需要设置。
+
+### hybrid_mode
+
+指定了混合读取器（Hybrid Reader）的操作模式，字符串参数。操作模式决定了如何处理和组合来自多个 IP 数据库的数据。
+
+可选参数为 `comparison` 与 `aggregation`，默认值为 `aggregation`。
+
+- `comparison`：比较模式，适用于需要跨不同 IP 数据库比较数据的场景，输出所有集成数据库的数据，便于识别每个源之间的差异和变化。
+- `aggregation`：聚合模式，适用于需要统一、全面视图的 IP 信息的情况，从多个源聚合数据，用一个数据库中的信息补充另一个数据库中缺失的字段。
 
 ### fields
 

--- a/docs/config_en.md
+++ b/docs/config_en.md
@@ -17,6 +17,7 @@
     * [ipv4_format](#ipv4format)
     * [ipv6_file](#ipv6file)
     * [ipv6_format](#ipv6format)
+    * [hybrid_mode](#hybridmode)
     * [fields](#fields)
     * [use_db_fields](#usedbfields)
     * [rewrite_files](#rewritefiles)
@@ -168,6 +169,15 @@ Specifies the database file used for IPv6 address queries, a string parameter, w
 Specifies the format of the IPv6 database file, a string parameter.
 
 When the database file suffix is insufficient to determine the file format, it is used to specify the format of the IPv6 database. Usually, it is not necessary to set this.
+
+### hybrid_mode
+
+Specifies the operational mode of the Hybrid Reader, a string parameter. The operational mode determines how data from multiple IP databases is processed and combined.
+
+Options are `comparison` and `aggregation`, with the default being `aggregation`.
+
+- `comparison`: Suitable for scenarios requiring data comparison across different IP databases. Outputs data from all integrated databases, facilitating the identification of discrepancies and variations between each source.
+- `aggregation`: Ideal for situations requiring a unified, comprehensive view of IP information. Aggregates data from multiple sources, supplementing missing fields from one database with information from another.
 
 ### fields
 

--- a/docs/dump.md
+++ b/docs/dump.md
@@ -30,6 +30,7 @@ ips dump -i inputFile [--input-format] [-o outputFile] [flags]
 - `-i, --input-file string`：指定输入 IP 数据库文件的路径。必填项。
 - `--input-format string`：指定输入 IP 数据库文件的格式。默认为自动检测。
 - `--input-option string`：数据库读取器指定选项。具体信息请查阅数据库文档。
+- `--hybrid-mode string`: 指定混合读取器的操作模式，可选值为 `comparison` 与 `aggregation`，参数详细解释请参考 [IPS 配置说明](./config.md#hybridmode)。
 - `-o, --output-file string`：指定转存文件的路径。不指定转存文件时，输出到标准输出流。
 - `--lang string`：设置输出信息的语言。默认为 `zh-CN` (中文)。
 - `-f, --fields string`：指定从输入文件中获取的字段。默认为所有字段。参数详细解释请参考 [IPS 配置说明](./config.md#fields)。

--- a/docs/dump_en.md
+++ b/docs/dump_en.md
@@ -31,6 +31,7 @@ ips dump -i inputFile [--input-format] [-o outputFile] [flags]
 - `-i, --input-file string`：Specifies the path to the input IP database file. Required.
 - `--input-format string`：Specifies the format of the input IP database file. Default is auto-detection.
 - `--input-option string`：Specifies options for the database reader. For more information, refer to the database documentation.
+- `--hybrid-mode string`: Specifies the operational mode for the Hybrid Reader. Options are `comparison` and `aggregation`. For more details, refer to [IPS Configuration Documentation](./config_en.md#hybridmode).
 - `-o, --output-file string`：Specifies the path to the dump file. When not specified, outputs to the standard output stream.
 - `--lang string`：Sets the language for the output information. Default is `zh-CN` (Chinese).
 - `-f, --fields string`：Specifies the fields to be extracted from the input file. Default is all fields. For a detailed explanation of the parameter, refer to  [IPS Configuration Documentation](./config_en.md#fields)。

--- a/docs/pack.md
+++ b/docs/pack.md
@@ -29,6 +29,7 @@ ips pack -i inputFile [--input-format format] -o outputFile [--output-format for
 - `-i, --input-file string`：指定输入 IP 数据库文件的路径。必填项。
 - `--input-format string`：指定输入 IP 数据库文件的格式。默认为自动检测。
 - `--input-option string`：数据库读取器指定选项。具体信息请查阅相关的数据库格式文档或获取专业支持。
+- `--hybrid-mode string`: 指定混合读取器的操作模式，可选值为 `comparison` 与 `aggregation`，参数详细解释请参考 [IPS 配置说明](./config.md#hybridmode)。
 - `-o, --output-file string`：指定输出 IP 数据库文件的路径。必填项。
 - `--output-format string`：指定输出 IP 数据库文件的格式。未指定时，使用输出文件的扩展名自动检测。
 - `--output-option string`：数据库写入器指定选项。具体信息请查阅相关的数据库格式文档或获取专业支持。

--- a/docs/pack_en.md
+++ b/docs/pack_en.md
@@ -29,6 +29,7 @@ ips pack -i inputFile [--input-format format] -o outputFile [--output-format for
 - `-i, --input-file string`：Specifies the path to the input IP database file. required.
 - `--input-format string`：Specifies the format of the input IP database file. The default is auto-detection.
 - `--input-option string`：Specifies options for the database reader. For more information, please consult the relevant database format documentation or obtain professional support.
+- `--hybrid-mode string`: Specifies the operational mode for the Hybrid Reader. Options are `comparison` and `aggregation`. For more details, refer to [IPS Configuration Documentation](./config_en.md#hybridmode).
 - `-o, --output-file string`：Specifies the path to the output IP database file. required.
 - `--output-format string`：Specifies the format of the output IP database file. If not specified, the format is auto-detected based on the output file extension.
 - `--output-option string`：Specifies options for the database writer. For more information, please consult the relevant database format documentation or obtain professional support.

--- a/docs/query.md
+++ b/docs/query.md
@@ -42,6 +42,7 @@ echo <ip or text> | ips [flags]
 - `--ipv4-format string`：指定 IPv4 数据库文件的格式，需要与 `--ipv4-file` 配合使用。默认为自动检测。
 - `--ipv6-file string`：指定 IPv6 数据库文件的路径。
 - `--ipv6-format string`：指定 IPv6 数据库文件的格式，需要与 `--ipv6-file` 配合使用。默认为自动检测。
+- `--hybrid-mode string`: 指定混合读取器的操作模式，可选值为 `comparison` 与 `aggregation`，参数详细解释请参考 [IPS 配置说明](./config.md#hybridmode)。
 - `--text-format string`：指定文本输出的格式，支持 %origin 和 %values 参数。
 - `--text-values-sep string`：指定文本输出中值的分隔符，默认为空格。
 - `-j, --json bool`：以 JSON 格式输出结果。

--- a/docs/query_en.md
+++ b/docs/query_en.md
@@ -41,6 +41,7 @@ echo <ip or text> | ips [flags]
 - `--ipv4-format string`：Specifies the format for the IPv4 database file; used in conjunction with `--ipv4-file`. The default is auto-detection.
 - `--ipv6-file string`：Specifies the path to the IPv6 database file.
 - `--ipv6-format string`：Specifies the format for the IPv6 database file; used in conjunction with `--ipv6-file`. The default is auto-detection.
+- `--hybrid-mode string`: Specifies the operational mode for the Hybrid Reader. Options are `comparison` and `aggregation`. For more details, refer to [IPS Configuration Documentation](./config_en.md#hybridmode).
 - `--text-format string`：Specifies the format for text output, supporting `%origin` and `%values` parameters.
 - `--text-values-sep string`：Specifies the separator for values in text output, with the default being a space.
 - `-j, --json bool`：Outputs results in JSON format.

--- a/docs/server.md
+++ b/docs/server.md
@@ -37,6 +37,7 @@ ips server [--addr address] [flags]
 - `--ipv4-format string`：指定 IPv4 数据库文件的格式，需要与 `--ipv4-file` 配合使用。默认为自动检测。
 - `--ipv6-file string`：指定 IPv6 数据库文件的路径。
 - `--ipv6-format string`：指定 IPv6 数据库文件的格式，需要与 `--ipv6-file` 配合使用。默认为自动检测。
+- `--hybrid-mode string`: 指定混合读取器的操作模式，可选值为 `comparison` 与 `aggregation`，参数详细解释请参考 [IPS 配置说明](./config.md#hybridmode)。
 - `--lang string`：设置输出信息的语言。默认为 `zh-CN` (中文)。参数详细解释请参考 [IPS 配置说明](./config.md#lang)。
 - `-f, --fields string`：指定从输入文件中获取的字段。默认为所有字段。参数详细解释请参考 [IPS 配置说明](./config.md#fields)。
 - `-r, --rewrite-files string`：指定需要载入的改写文件列表。参数详细解释请参考 [IPS 配置说明](./config.md#rewritefiles)。

--- a/docs/server_en.md
+++ b/docs/server_en.md
@@ -22,6 +22,7 @@ ips server [--addr address] [flags]
 - `--ipv4-format string`：Specifies the format for the IPv4 database file; used in conjunction with `--ipv4-file`. The default is auto-detection.
 - `--ipv6-file string`：Specifies the path to the IPv6 database file.
 - `--ipv6-format string`：Specifies the format for the IPv6 database file; used in conjunction with `--ipv6-file`. The default is auto-detection.
+- `--hybrid-mode string`: Specifies the operational mode for the Hybrid Reader. Options are `comparison` and `aggregation`. For more details, refer to [IPS Configuration Documentation](./config_en.md#hybridmode).
 - `--lang string`：Sets the language for the output. The default is `zh-CN` (Chinese). For more details, refer to [IPS Configuration Documentation](./config_en.md#lang)。
 - `-f, --fields string`：Specifies the fields to retrieve from the input file. The default is all fields. For more details, refer to [IPS Configuration Documentation](./config_en.md#fields)。
 - `-r, --rewrite-files string`：Specifies a list of files to be rewritten based on the provided configurations. For more details, refer to [IPS Configuration Documentation](./config_en.md#rewritefiles)。

--- a/internal/ipio/hybrid_reader.go
+++ b/internal/ipio/hybrid_reader.go
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2023 shenjunzheng@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ipio
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/sjzar/ips/format"
+	"github.com/sjzar/ips/internal/operate"
+	"github.com/sjzar/ips/pkg/errors"
+	"github.com/sjzar/ips/pkg/model"
+)
+
+const (
+	// HybridComparisonMode is used in scenarios where the goal is to compare data
+	// across multiple IP database readers. In this mode, the output includes data
+	// from all readers, facilitating a comprehensive comparison of the differences
+	// between each data source. This mode is particularly useful for analyzing
+	// discrepancies and inconsistencies across various IP databases.
+	HybridComparisonMode = "comparison"
+
+	// HybridAggregationMode is designed for situations where a unified view of data
+	// is needed. In this mode, the output is a single, aggregated set of data that
+	// combines information from all the IP database readers. If a particular field is
+	// missing from one reader, it is supplemented by another, ensuring a more
+	// complete and cohesive dataset. This mode is ideal for creating a comprehensive
+	// and enriched view of IP information by leveraging the strengths of multiple databases.
+	HybridAggregationMode = "aggregation"
+)
+
+// HybridReader integrates multiple IP database readers into a single entity.
+// It supports various operational modes (like comparison and aggregation) for querying
+// and combining results from different IP databases.
+type HybridReader struct {
+	OperateChain *operate.IPOperateChain // Chain of operations to be applied to IP information.
+	dbReaders    []format.Reader         // Collection of database readers.
+	meta         *model.Meta             // Combined metadata from all readers.
+	hybridMode   string                  // Operational mode of the HybridReader.
+}
+
+// NewHybridReader constructs a new HybridReader with the provided IP operation chain and database readers.
+// It initializes the reader's metadata by merging metadata from all provided readers.
+func NewHybridReader(operateChain *operate.IPOperateChain, dbReaders ...format.Reader) (*HybridReader, error) {
+	// Check if there are any readers provided
+	if len(dbReaders) == 0 {
+		return nil, errors.ErrNoDatabaseReaders
+	}
+
+	if operateChain == nil {
+		operateChain = operate.NewIPOperateChain()
+	}
+
+	// Initialize meta with the first reader's meta information
+	hybridMeta := &model.Meta{
+		Fields:     make([]string, 0),
+		FieldAlias: make(map[string]string),
+	}
+
+	// Merge Fields and FieldAlias from all readers
+	for i, reader := range dbReaders {
+		readerMeta := reader.Meta()
+		if i == 0 {
+			hybridMeta.MetaVersion = readerMeta.MetaVersion
+			hybridMeta.IPVersion = readerMeta.IPVersion
+			hybridMeta.Format = readerMeta.Format
+		}
+
+		for _, field := range readerMeta.Fields {
+			if strings.HasPrefix(field, fmt.Sprintf("%d_", i)) {
+				hybridMeta.Fields = append(hybridMeta.Fields, field)
+				continue
+			}
+			if split := strings.SplitN(field, "_", 2); len(split) == 2 {
+				if _, err := strconv.ParseInt(split[0], 10, 64); err == nil {
+					continue
+				}
+			}
+			prefixedField := fmt.Sprintf("%d_%s", i, field)
+			hybridMeta.Fields = append(hybridMeta.Fields, prefixedField)
+		}
+
+		for key, value := range readerMeta.FieldAlias {
+			prefixedKey := fmt.Sprintf("%d_%s", i, key)
+			prefixedVal := fmt.Sprintf("%d_%s", i, value)
+			hybridMeta.FieldAlias[prefixedKey] = prefixedVal
+		}
+	}
+
+	return &HybridReader{
+		OperateChain: operateChain,
+		dbReaders:    dbReaders,
+		meta:         hybridMeta,
+	}, nil
+}
+
+// Meta returns the combined metadata of the IP databases attached to the HybridReader.
+func (h *HybridReader) Meta() *model.Meta {
+	return h.meta
+}
+
+// Find performs parallel queries across all underlying database readers using the specified IP address.
+// It combines the results based on the operational mode of the HybridReader: either comparing data or aggregating it.
+func (h *HybridReader) Find(ip net.IP) (*model.IPInfo, error) {
+	var wg sync.WaitGroup
+	results := make([]*model.IPInfo, len(h.dbReaders))
+	errs := make([]error, len(h.dbReaders))
+
+	// Parallel query from each Reader
+	for i, reader := range h.dbReaders {
+		wg.Add(1)
+		go func(index int, rd format.Reader) {
+			defer wg.Done()
+			result, err := rd.Find(ip)
+			results[index] = result
+			if err != nil {
+				errs[index] = fmt.Errorf("error in Reader %d: %w", index, err)
+			}
+		}(i, reader)
+	}
+
+	wg.Wait()
+
+	// Check for errors and combine results
+	hybridIPInfo := &model.IPInfo{
+		IP:            ip,
+		Data:          make(map[string]string),
+		FieldAlias:    h.Meta().FieldAlias,
+		Fields:        h.Meta().Fields,
+		ReplaceFields: make(map[string]string),
+	}
+
+	for _, err := range errs {
+		if err != nil {
+			// Return the first non-nil error with reader index
+			return nil, err
+		}
+	}
+
+	for i, result := range results {
+		if i == 0 {
+			hybridIPInfo.IPNet = result.IPNet
+		} else if ok := hybridIPInfo.IPNet.CommonRange(ip, result.IPNet); !ok {
+			log.Debug("IPNet.CommonRange() failed ", hybridIPInfo.IPNet, ip, result.IPNet)
+		}
+
+		for key, value := range result.Data {
+			prefixedKey := fmt.Sprintf("%d_%s", i, key)
+			hybridIPInfo.Data[prefixedKey] = value
+		}
+
+		for key, value := range result.ReplaceFields {
+			prefixedKey := fmt.Sprintf("%d_%s", i, key)
+			hybridIPInfo.ReplaceFields[prefixedKey] = value
+		}
+
+		switch h.hybridMode {
+		case HybridComparisonMode:
+		default:
+			// HybridAggregationMode
+			for _, field := range h.Meta().Fields {
+				if _, ok := hybridIPInfo.Data[field]; ok {
+					continue
+				}
+				val, ok := result.GetData(field)
+				if !ok {
+					continue
+				}
+				hybridIPInfo.Data[field] = val
+				if replaceVal, ok := result.ReplaceFields[field]; ok {
+					hybridIPInfo.Data[field] = replaceVal
+				}
+			}
+		}
+	}
+
+	if h.OperateChain != nil {
+		if err := h.OperateChain.Do(hybridIPInfo); err != nil {
+			return nil, err
+		}
+	}
+
+	return hybridIPInfo, nil
+}
+
+type HybridReaderOption struct {
+	Mode string
+}
+
+// SetOption configures the HybridReader with the provided option, particularly the operational mode.
+func (h *HybridReader) SetOption(option interface{}) error {
+	if opt, ok := option.(HybridReaderOption); ok {
+		h.hybridMode = opt.Mode
+	}
+	return nil
+}
+
+// Close method ensures that all underlying database readers are properly closed.
+func (h *HybridReader) Close() error {
+	for _, reader := range h.dbReaders {
+		if err := reader.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/ips/config.go
+++ b/internal/ips/config.go
@@ -18,14 +18,12 @@ package ips
 
 import (
 	"fmt"
-
-	"github.com/spf13/viper"
+	"strings"
 )
 
 func init() {
 	// Set Persistence Default Values
-	viper.SetDefault("ipv4_file", "qqwry.dat")
-	viper.SetDefault("ipv6_file", "zxipv6wry.db")
+	// viper.SetDefault("ipv4_file", []string{"qqwry.dat"})
 }
 
 const (
@@ -54,16 +52,23 @@ type Config struct {
 
 	// Find
 	// IPv4File specifies the file is IPv4 database.
-	IPv4File string `mapstructure:"ipv4_file"`
+	IPv4File []string `mapstructure:"ipv4_file" default:"[\"qqwry.dat\"]"`
 
 	// IPv4Format specifies the format for IPv4 database.
-	IPv4Format string `mapstructure:"ipv4_format"`
+	IPv4Format []string `mapstructure:"ipv4_format"`
 
 	// IPv6File specifies the file is IPv6 database.
-	IPv6File string `mapstructure:"ipv6_file"`
+	IPv6File []string `mapstructure:"ipv6_file" default:"[\"zxipv6wry.db\"]"`
 
 	// IPv6Format specifies the format for IPv6 database.
-	IPv6Format string `mapstructure:"ipv6_format"`
+	IPv6Format []string `mapstructure:"ipv6_format"`
+
+	// HybridMode specifies the operational mode of the HybridReader.
+	// It determines how the HybridReader processes and combines data from multiple IP database readers.
+	// Accepted values are "comparison" and "aggregation":
+	// - "comparison": Used for comparing data across different databases, where the output includes data from all readers.
+	// - "aggregation": Used for creating a unified view of data by aggregating and supplementing missing fields from multiple databases. (default)
+	HybridMode string `mapstructure:"hybrid_mode"`
 
 	// Fields lists the output fields.
 	// default is country, province, city, isp
@@ -122,13 +127,19 @@ type Config struct {
 
 func (c *Config) ShowConfig(allKeys bool) string {
 	str := fmt.Sprintf("ips dir:\t\t[%s]\n", c.IPSDir)
-	str += fmt.Sprintf("ipv4_file(ipv4):\t[%s]\n", c.IPv4File)
-	if allKeys || len(c.IPv4Format) > 0 {
-		str += fmt.Sprintf("ipv4_format:\t\t[%s]\n", c.IPv4Format)
+	if allKeys || len(c.Lang) > 0 {
+		str += fmt.Sprintf("lang:\t\t\t[%s]\n", c.Lang)
 	}
-	str += fmt.Sprintf("ipv6_file(ipv6):\t[%s]\n", c.IPv6File)
+	str += fmt.Sprintf("ipv4_file(ipv4):\t[%s]\n", strings.Join(c.IPv4File, ","))
+	if allKeys || len(c.IPv4Format) > 0 {
+		str += fmt.Sprintf("ipv4_format:\t\t[%s]\n", strings.Join(c.IPv4Format, ","))
+	}
+	str += fmt.Sprintf("ipv6_file(ipv6):\t[%s]\n", strings.Join(c.IPv6File, ","))
 	if allKeys || len(c.IPv6Format) > 0 {
-		str += fmt.Sprintf("ipv6_format:\t\t[%s]\n", c.IPv6Format)
+		str += fmt.Sprintf("ipv6_format:\t\t[%s]\n", strings.Join(c.IPv6Format, ","))
+	}
+	if allKeys || len(c.HybridMode) > 0 {
+		str += fmt.Sprintf("hybrid_mode:\t\t[%s]\n", c.HybridMode)
 	}
 	if allKeys || len(c.Fields) > 0 {
 		str += fmt.Sprintf("fields:\t\t\t[%s]\n", c.Fields)
@@ -157,5 +168,24 @@ func (c *Config) ShowConfig(allKeys bool) string {
 	if allKeys || len(c.DPRewriterFiles) > 0 {
 		str += fmt.Sprintf("dp_rewriter_files:\t[%s]\n", c.DPRewriterFiles)
 	}
+	if allKeys || len(c.ReaderOption) > 0 {
+		str += fmt.Sprintf("reader_option:\t\t[%s]\n", c.ReaderOption)
+	}
+	if allKeys || len(c.WriterOption) > 0 {
+		str += fmt.Sprintf("writer_option:\t\t[%s]\n", c.WriterOption)
+	}
+	if allKeys || len(c.LocalAddr) > 0 {
+		str += fmt.Sprintf("local_addr:\t\t[%s]\n", c.LocalAddr)
+	}
+	if allKeys || c.MyIPCount > 0 {
+		str += fmt.Sprintf("myip_count:\t\t[%d]\n", c.MyIPCount)
+	}
+	if allKeys || c.MyIPTimeoutS > 0 {
+		str += fmt.Sprintf("myip_timeout_s:\t\t[%d]\n", c.MyIPTimeoutS)
+	}
+	if allKeys || len(c.Addr) > 0 {
+		str += fmt.Sprintf("addr:\t\t\t[%s]\n", c.Addr)
+	}
+
 	return str
 }

--- a/internal/ips/service.go
+++ b/internal/ips/service.go
@@ -120,15 +120,9 @@ func (m *Manager) GetQuery(c *gin.Context) {
 		text = c.Request.URL.RawQuery
 	}
 
+	ret := &model.DataList{}
+
 	tp := parser.NewTextParser(text).Parse()
-
-	type Result struct {
-		Items []interface{} `json:"items"`
-	}
-
-	ret := Result{
-		Items: make([]interface{}, 0),
-	}
 
 	for _, segment := range tp.Segments {
 		info, err := m.parseSegment(segment)
@@ -139,7 +133,9 @@ func (m *Manager) GetQuery(c *gin.Context) {
 
 		switch v := info.(type) {
 		case *model.IPInfo:
-			ret.Items = append(ret.Items, v.Output(m.Conf.UseDBFields))
+			ret.AddItem(v.Output(m.Conf.UseDBFields))
+		case *model.DomainInfo:
+			ret.AddDomain(v)
 		}
 	}
 

--- a/internal/ips/static/index.js
+++ b/internal/ips/static/index.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", function() {
     function queryIP() {
         clearTimeout(timer);
 
-        const inputText = inputBox.value;
+        const inputText = encodeURI(inputBox.value);
 
         if (inputText) {
             fetch(`/api/v1/query?text=${inputText}`)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -26,12 +26,17 @@ var (
 	ErrUnsupportedIPVersion   = errors.New("unsupported IP version")
 	ErrUnsupportedFormat      = errors.New("unsupported format")
 	ErrInvalidDatabase        = errors.New("invalid database")
+	ErrInvalidFormat          = errors.New("invalid format")
 	ErrMismatchedFieldsLength = errors.New("mismatched fields length")
 	ErrInvalidCIDR            = errors.New("invalid CIDR format")
 	ErrCIDROverlap            = errors.New("CIDR overlap detected")
 	ErrMetaMissing            = errors.New("meta information missing")
 	ErrNilWriter              = errors.New("writer is not initialized")
 	ErrUnsupportedLanguage    = errors.New("unsupported language")
+
+	// IPio
+
+	ErrNoDatabaseReaders = errors.New("no database readers provided")
 
 	// Operate
 

--- a/pkg/model/ipinfo.go
+++ b/pkg/model/ipinfo.go
@@ -70,9 +70,7 @@ func (i *IPInfo) AddCommonFieldAlias(fieldAlias map[string]string) {
 	}
 
 	for commonField, dbField := range fieldAlias {
-		if _, ok := i.Data[dbField]; ok {
-			i.FieldAlias[commonField] = dbField
-		}
+		i.FieldAlias[commonField] = dbField
 	}
 }
 

--- a/pkg/model/output.go
+++ b/pkg/model/output.go
@@ -46,7 +46,8 @@ type AlfredText struct {
 
 // DataList holds a list of items to be displayed in Alfred's result list.
 type DataList struct {
-	Items []interface{} `json:"items"`
+	Items   []interface{} `json:"items,omitempty"`
+	Domains []interface{} `json:"domains,omitempty"`
 }
 
 // AddItem appends a new item to the DataList's Items slice.
@@ -55,6 +56,14 @@ func (d *DataList) AddItem(item interface{}) {
 		d.Items = make([]interface{}, 0)
 	}
 	d.Items = append(d.Items, item)
+}
+
+// AddDomain appends a new item to the DataList's Domains slice.
+func (d *DataList) AddDomain(domain interface{}) {
+	if d.Domains == nil {
+		d.Domains = make([]interface{}, 0)
+	}
+	d.Domains = append(d.Domains, domain)
 }
 
 // AddAlfredItemByIPInfo creates an AlfredItem from the provided IPInfo


### PR DESCRIPTION
- 新增混合读取器功能：
  - 支持同时从多个 IP 数据库中读取数据。
  - 支持对查询结果进行比较和聚合处理。
  - 在 `ips` 相关命令中，IP 数据库文件和格式字段现支持列表形式设置。
  - `ips config` 命令新增对列表数据的支持。
  - 更新 IPS 数据库初始化函数，以适配混合读取器。
- `ips` 查询功能的管道模式现支持 `\r` 和 `\n` 换行符（方案来源于 nali）。
- `ips server` 新增域名信息查询功能。
- JSON 返回值中，IP 与 Domain 信息现分为不同的列表。

---
- Added Hybrid Reader:
  - Capable of reading from multiple IP databases simultaneously.
  - Enables comparison and aggregation of query results.
  - In `ips` commands, the IP database file and format fields can be set as lists.
  - `ips config` command now supports setting list data.
  - Updated the IPS database initialization function for Hybrid Reader support.
- `ips` query function's pipeline mode now handles both `\r` and `\n` newline characters (inspired by nali).
- `ips server` includes domain information querying capability.
- In JSON responses, IP and Domain information are now separated into distinct lists.