### PR TITLE
support czdb format

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ brew install ips
 | mmdb      | ✅  | ✅  | ✅  | [Link](https://maxmind.com)                       |           |
 | awdb      | ✅  | ✅  | -  | [Link](https://ipplus360.com)                     |           |
 | qqwry     | ✅  | ✅  | -  | [Link](https://cz88.net)                          | IPv4 only |
+| czdb      | ✅  | ✅  | -  | [Link](https://cz88.net)                          |           |
 | zxinc     | ✅  | ✅  | -  | [Link](https://ip.zxinc.org)                      | IPv6 only |
 | ip2region | ✅  | ✅  | -  | [Link](https://github.com/lionsoul2014/ip2region) | IPv4 only |
 
@@ -127,7 +128,7 @@ ips pack -i qqwry.dat -f country -o country.ipdb
 * [IPIP.net](https://ipip.net) 的 ipdb 数据库格式
 * [MaxMind](https://maxmind.com) 的 mmdb 数据库格式
 * [埃文科技](https://ipplus360.com) 的 awdb 数据库格式
-* [纯真网络](https://cz88.net) 的 qqwry 数据库格式
+* [纯真网络](https://cz88.net) 的 qqwry 和 czdb 数据库格式
 * [ip.zxinc.org](https://ip.zxinc.org) 的 zxinc 数据库格式
 * [@lionsoul2014](https://github.com/lionsoul2014) 的 [ip2region](https://github.com/lionsoul2014/ip2region) 数据库格式
 * [@zu1k](https://github.com/zu1k) 的 [nali](https://github.com/zu1k/nali) 项目，本项目查询功能参考了 nali 的方案

--- a/README_en.md
+++ b/README_en.md
@@ -50,6 +50,7 @@ brew install ips
 | mmdb      | ✅     | ✅    | ✅    | [Link](https://maxmind.com)                       |                        |
 | awdb      | ✅     | ✅    | -    | [Link](https://ipplus360.com)                     |                        |
 | qqwry     | ✅     | ✅    | -    | [Link](https://cz88.net)                          | IPv4 only              |
+| czdb      | ✅     | ✅    | -    | [Link](https://cz88.net)                          |                        |
 | zxinc     | ✅     | ✅    | -    | [Link](https://ip.zxinc.org)                      | IPv6 only              |
 | ip2region | ✅     | ✅    | -    | [Link](https://github.com/lionsoul2014/ip2region) | IPv4 only              |
 
@@ -127,7 +128,7 @@ ips pack -i qqwry.dat -f country -o country.ipdb
 * [IPIP.net](https://ipip.net) for the ipdb database format
 * [MaxMind](https://maxmind.com) for the mmdb database format
 * [埃文科技](https://ipplus360.com) for the awdb database format
-* [纯真网络](https://cz88.net) for the qqwry database format
+* [纯真网络](https://cz88.net) for the qqwry and czdb database format
 * [ip.zxinc.org](https://ip.zxinc.org) for the zxinc database format
 * [@lionsoul2014](https://github.com/lionsoul2014) for the [ip2region](https://github.com/lionsoul2014/ip2region) database format
 * [@zu1k](https://github.com/zu1k) for the [nali](https://github.com/zu1k/nali) project, from which this project's querying feature was inspired

--- a/format/czdb/doc.go
+++ b/format/czdb/doc.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024 shenjunzheng@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package czdb
+
+/* CZDB Format
+	+--------------------------------+
+	|          Hyper Header          |
+	+--------------------------------+
+	|           Super Part           |
+	+--------------------------------+
+	|          Header Block          |
+	+--------------------------------+
+	|           Data Block           |
+	+--------------------------------+
+	|          Index Block           |
+	+--------------------------------+
+	|          Geo Map Block         |
+	+--------------------------------+
+	|            Copyright           |
+	+--------------------------------+
+
+* All multi-byte integers are stored in Little Endian
+* All offsets are calculated from the start of Super Part
+* String encoding is UTF-8 unless specified otherwise
+
+Hyper Header
+	+--------------------------------+--------------------------------+--------------------------------+
+	|         Version (4byte)        |       Client ID (4byte)        | Encrypted Data Length (4byte)  |
+	+--------------------------------+--------------------------------+--------------------------------+
+	|                                     Encrypted Data (n byte)                                      |
+	+--------------------------------+--------------------------------+--------------------------------+
+	|                                      Random Bytes (n byte)                                       |
+	+--------------------------------+--------------------------------+--------------------------------+
+* Version format is "YYYYMMDD" in decimal, e.g. 20241211
+
+Encrypted Data
+	+--------------------------------+--------------------------------+--------------------------------+
+	|       Client ID (3byte)        |    Expiration Date (5byte)     |  Random Bytes Length (4byte)   |
+	+--------------------------------+--------------------------------+--------------------------------+
+* AES-128 ECB PKCS5 encrypted
+* Expiration Date format is "YYMMDD" in decimal, e.g. 251216
+
+Super Part
+	+--------------------------------+--------------------------------+
+	|        DB Type (1byte)         |       File Size (4byte)        |
+	+--------------------------------+--------------------------------+
+	|     First Index Ptr (4byte)    | Total Header Block Size (4byte)|
+	+--------------------------------+--------------------------------+
+	|     Last Index Ptr (4byte)     |
+	+--------------------------------+
+* DB Type is 0x0 for IPv4, else for IPv6
+* File Size is the size starting from Super Part to the end of the file
+* First Index Ptr and Last Index Ptr offset from the start of Super Part
+
+Header Block (single element)
+	+--------------------------------+--------------------------------+
+	|       Start IP (16byte)        |       Index Ptr (4byte)        |
+	+--------------------------------+--------------------------------+
+* Start IP is IPv4 or IPv6, IPv4 use first 4 bytes, IPv6 use all 16 bytes
+* Index Ptr offset from the start of Super Part
+
+Data Block (single element)
+	+--------------------------------+--------------------------------+
+	|     Geo Data Length (2byte)    |      Geo Data Ptr (6byte)      |
+	+--------------------------------+--------------------------------+
+	|                       Other Data (n byte)                       |
+	+--------------------------------+--------------------------------+
+* Data Block is msgpack format
+* Geo Data Ptr offset from the start of Super Part
+* Other Data is string format
+
+Index Block (single element)
+	+--------------------------------+--------------------------------+
+	|                   Start IP (4byte or 16byte)                    |
+	+--------------------------------+--------------------------------+
+	|                    End IP (4byte or 16byte)                     |
+	+--------------------------------+--------------------------------+
+	|         Data Ptr (4byte)       |      Data Length (1byte)       |
+	+--------------------------------+--------------------------------+
+* Start IP and End IP is IPv4 or IPv6, IPv4 use 4 bytes, IPv6 use 16 bytes
+* Data Ptr offset from the start of Super Part
+
+Geo Map Block
+	+--------------------------------+--------------------------------+
+	|    Column Selection (4byte)    |    Geo Data Length (4byte)     |
+	+--------------------------------+--------------------------------+
+	|                        Geo Data (n byte)                        |
+	+--------------------------------+--------------------------------+
+* Column Selection is a bitwise flag indicating which columns are selected
+* if Column Selection is 0, Geo Map not exists
+* Geo Data be decrypted by XOR (Vigenère cipher like)
+* Geo Data is msgpack format
+
+Copyright
+* like "Copyright © 2024 All Rights Reserved. cz88.net 2024/12/04"
+
+*/

--- a/format/czdb/fields.go
+++ b/format/czdb/fields.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 shenjunzheng@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package czdb
+
+import (
+	"github.com/sjzar/ips/pkg/model"
+)
+
+// cidr,country,area
+// 1.2.2.0/24,北京市海淀区,北龙中网(北京)科技有限公司
+// 1.2.8.0/24,中国,网络信息中心
+// 1.2.9.0/24,广东省,电信
+// 1.8.151.0/24,香港,特别行政区
+// 1.10.140.0/25,泰国, CZ88.NET
+// 1.12.36.0/22,广东省广州市,腾讯云
+// * Country 和 Area 中的数据比较混乱，需要后续改写处理
+
+const (
+	FieldCountry = "country"
+	FieldArea    = "area"
+)
+
+// FullFields 全字段列表
+var FullFields = []string{
+	FieldCountry,
+	FieldArea,
+}
+
+// CommonFieldsAlias 公共字段到数据库字段映射
+var CommonFieldsAlias = map[string]string{
+	model.Country: FieldCountry,
+	model.ISP:     FieldArea,
+}

--- a/format/czdb/reader.go
+++ b/format/czdb/reader.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024 shenjunzheng@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package czdb
+
+import (
+	"net"
+	"strings"
+
+	"github.com/sjzar/ips/format/czdb/sdk"
+	"github.com/sjzar/ips/pkg/model"
+)
+
+const (
+	DBFormat = "czdb"
+	DBExt    = ".czdb"
+	DBKey    = ""
+)
+
+// Reader is a structure that provides functionalities to read from CZDB IP database.
+type Reader struct {
+	meta   *model.Meta  // Metadata of the IP database
+	db     *sdk.Reader  // Database reader instance
+	option ReaderOption // Configuration options for the reader.
+}
+
+// NewReader initializes a new instance of Reader.
+func NewReader(file string) (*Reader, error) {
+
+	db, err := sdk.NewReader(file)
+	if err != nil {
+		return nil, err
+	}
+
+	meta := &model.Meta{
+		MetaVersion: model.MetaVersion,
+		Format:      DBFormat,
+		IPVersion:   model.IPv4,
+		Fields:      FullFields,
+	}
+	meta.AddCommonFieldAlias(CommonFieldsAlias)
+
+	return &Reader{
+		meta: meta,
+		db:   db,
+	}, nil
+}
+
+func (r *Reader) Meta() *model.Meta {
+	return r.meta
+}
+
+func (r *Reader) Find(ip net.IP) (*model.IPInfo, error) {
+	ipr, country, err := r.db.Find(ip)
+	if err != nil {
+		return nil, err
+	}
+
+	area := ""
+	split := strings.SplitN(country, "\t", 2)
+	if len(split) == 2 {
+		country, area = split[0], split[1]
+	}
+
+	ret := &model.IPInfo{
+		IP:     ip,
+		IPNet:  ipr,
+		Fields: r.meta.Fields,
+		Data: map[string]string{
+			FieldCountry: country,
+			FieldArea:    area,
+		},
+	}
+	ret.AddCommonFieldAlias(CommonFieldsAlias)
+
+	return ret, nil
+}
+
+// ReaderOption contains configuration options for the Reader.
+type ReaderOption struct {
+	Key string
+}
+
+// SetOption applies the provided option to the Reader's configuration.
+func (r *Reader) SetOption(option interface{}) error {
+	if opt, ok := option.(ReaderOption); ok {
+		r.db.Key = opt.Key
+		r.option = opt
+	}
+
+	// FIXME: init database with key
+	if r.db.Key != "" {
+		if err := r.db.Init(); err == nil {
+			if r.db.IsIPv4() {
+				r.meta.IPVersion = model.IPv4
+			}
+			if r.db.IsIPv6() {
+				r.meta.IPVersion = model.IPv6
+			}
+		}
+	}
+	return nil
+}
+
+// Close releases any resources used by the Reader and closes the MMDB database.
+func (r *Reader) Close() error {
+	return r.db.Close()
+}

--- a/format/czdb/sdk/cipher.go
+++ b/format/czdb/sdk/cipher.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025 shenjunzheng@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sdk
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+)
+
+// XorDecrypt decrypts the data using the XOR algorithm.
+// For decrypting geo data.
+func XorDecrypt(data []byte, key []byte) []byte {
+	result := make([]byte, len(data))
+	for i := 0; i < len(data); i++ {
+		result[i] = data[i] ^ key[i%len(key)]
+	}
+	return result
+}
+
+// implement the AES ECB support
+// https://github.com/golang/go/issues/5597
+
+func AesECBEncrypt(origData, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	origData = PKCS5Padding(origData, block.BlockSize())
+	blockMode := NewECBEncrypter(block)
+	crypted := make([]byte, len(origData))
+	blockMode.CryptBlocks(crypted, origData)
+	return crypted, nil
+}
+
+func AesECBDecrypt(crypted, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	blockMode := NewECBDecrypter(block)
+	origData := make([]byte, len(crypted))
+	blockMode.CryptBlocks(origData, crypted)
+	origData = PKCS5UnPadding(origData)
+	return origData, nil
+}
+
+func PKCS5Padding(ciphertext []byte, blockSize int) []byte {
+	padding := blockSize - len(ciphertext)%blockSize
+	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
+	return append(ciphertext, padtext...)
+}
+
+func PKCS5UnPadding(origData []byte) []byte {
+	length := len(origData)
+	unpadding := int(origData[length-1])
+	return origData[:(length - unpadding)]
+}
+
+// Copy From https://codereview.appspot.com/7860047/patch/23001/24001
+
+// Electronic Code Book (ECB) mode.
+
+// ECB provides confidentiality by assigning a fixed ciphertext block to each
+// plaintext block.
+
+// See NIST SP 800-38A, pp 08-09
+
+type ecb struct {
+	b         cipher.Block
+	blockSize int
+}
+
+func newECB(b cipher.Block) *ecb {
+	return &ecb{
+		b:         b,
+		blockSize: b.BlockSize(),
+	}
+}
+
+type ecbEncrypter ecb
+
+// NewECBEncrypter returns a BlockMode which encrypts in electronic code book
+// mode, using the given Block.
+func NewECBEncrypter(b cipher.Block) cipher.BlockMode {
+	return (*ecbEncrypter)(newECB(b))
+}
+
+func (x *ecbEncrypter) BlockSize() int { return x.blockSize }
+
+func (x *ecbEncrypter) CryptBlocks(dst, src []byte) {
+	if len(src)%x.blockSize != 0 {
+		panic("crypto/cipher: input not full blocks")
+	}
+	if len(dst) < len(src) {
+		panic("crypto/cipher: output smaller than input")
+	}
+	for len(src) > 0 {
+		x.b.Encrypt(dst, src[:x.blockSize])
+		src = src[x.blockSize:]
+		dst = dst[x.blockSize:]
+	}
+}
+
+type ecbDecrypter ecb
+
+// NewECBDecrypter returns a BlockMode which decrypts in electronic code book
+// mode, using the given Block.
+func NewECBDecrypter(b cipher.Block) cipher.BlockMode {
+	return (*ecbDecrypter)(newECB(b))
+}
+
+func (x *ecbDecrypter) BlockSize() int { return x.blockSize }
+
+func (x *ecbDecrypter) CryptBlocks(dst, src []byte) {
+	if len(src)%x.blockSize != 0 {
+		panic("crypto/cipher: input not full blocks")
+	}
+	if len(dst) < len(src) {
+		panic("crypto/cipher: output smaller than input")
+	}
+	for len(src) > 0 {
+		x.b.Decrypt(dst, src[:x.blockSize])
+		src = src[x.blockSize:]
+		dst = dst[x.blockSize:]
+	}
+}

--- a/format/czdb/sdk/const.go
+++ b/format/czdb/sdk/const.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 shenjunzheng@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sdk
+
+const (
+	// HyperHeaderLength represents the length of the hyper header
+	// not including encrypted data and random bytes
+	HyperHeaderLength = 12
+
+	// SuperPartLength represents the length of the super part
+	// 1 byte DB Type
+	// 4 bytes File Size
+	// 4 bytes First Index Ptr
+	// 4 bytes Total Header Block Size
+	// 4 bytes Last Index Ptr
+	SuperPartLength = 17
+
+	// HeaderBlockLength represents the length of the header block
+	// 16 bytes Start IP
+	// 4 bytes Index Ptr
+	HeaderBlockLength = 20
+
+	// IPv4 is bitwise representation of the IP version
+	IPv4 = 0x0
+
+	// IPv4Length represents the length of an IPv4 address
+	IPv4Length = 4
+
+	// IPv4IndexBlockLength represents the length of an IPv4 index block
+	// 4 bytes Start IP
+	// 4 bytes End IP
+	// 4 bytes Data Ptr
+	// 1 byte Data Length
+	IPv4IndexBlockLength = 13
+
+	// IPv6 is bitwise representation of the IP version
+	IPv6 = 0x1
+
+	// IPv6Length represents the length of an IPv6 address
+	IPv6Length = 16
+
+	// IPv6IndexBlockLength represents the length of an IPv6 index block
+	// 16 bytes Start IP
+	// 16 bytes End IP
+	// 4 bytes Data Ptr
+	// 1 byte Data Length
+	IPv6IndexBlockLength = 37
+
+	// FIXME: official database is incomplete, wait for official processing.
+	TempDataNotFound = "DataNotFound"
+)

--- a/format/czdb/sdk/geo.go
+++ b/format/czdb/sdk/geo.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 shenjunzheng@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sdk
+
+import (
+	"bytes"
+
+	"github.com/sjzar/ips/pkg/errors"
+
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// Geo handles the parsing and interpretation of geographical data in MessagePack format.
+// It manages column selection and data decoding based on the database configuration.
+type Geo struct {
+	data            []byte
+	columnSelection int
+}
+
+// ParseGeoInfo decodes and formats geographical information from binary data.
+func (g *Geo) ParseGeoInfo(data []byte) (string, error) {
+
+	decoder := msgpack.NewDecoder(bytes.NewReader(data))
+	geoPosMixSize, err := decoder.DecodeInt64()
+	if err != nil {
+		return "", err
+	}
+
+	otherData, err := decoder.DecodeString()
+	if err != nil {
+		return "", err
+	}
+
+	if geoPosMixSize == 0 {
+		return otherData, nil
+	}
+
+	dataLen := int((geoPosMixSize >> 24) & 0xFF)
+	dataPtr := int(geoPosMixSize & 0x00FFFFFF)
+
+	if len(g.data) < dataPtr+dataLen {
+		return "", errors.ErrInvalidDatabase
+	}
+
+	var info string
+	decoder = msgpack.NewDecoder(bytes.NewReader(g.data[dataPtr : dataPtr+dataLen]))
+	columnNumber, err := decoder.DecodeArrayLen()
+	if err != nil {
+		return "", err
+	}
+
+	for i := 0; i < columnNumber; i++ {
+		value, err := decoder.DecodeString()
+		if err != nil {
+			return "", err
+		}
+
+		// columnSelected
+		if (g.columnSelection>>(i+1))&1 == 1 {
+			if value == "" {
+				value = "null"
+			}
+			info += value
+			info += "\t"
+		}
+	}
+
+	return info + "\t" + otherData, nil
+}

--- a/format/czdb/sdk/parser.go
+++ b/format/czdb/sdk/parser.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025 shenjunzheng@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sdk
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+
+	"github.com/sjzar/ips/pkg/errors"
+)
+
+// validateKey checks if the decryption key is valid and properly formatted.
+// Verifies:
+// - Key is not empty
+// - Key is valid base64 encoded
+// Returns:
+// - error: ErrKeyRequired if key is empty or decoding error
+func (r *Reader) validateKey() error {
+	if r.Key == "" {
+		return errors.ErrKeyRequired
+	}
+	_, err := base64.StdEncoding.DecodeString(r.Key)
+	return err
+}
+
+// decryptHyperHeader decrypts the encrypted hyper header section using AES-ECB.
+// Populates:
+// - decClientID: decoded client identifier
+// - decExpirationDate: database expiration date, format is "YYMMDD" in decimal, e.g. 251216
+// - decRandomBytesLength: length of random padding bytes
+// Returns:
+// - error: decryption failures or invalid header format
+func (r *Reader) decryptHyperHeader() error {
+	keyBytes, err := base64.StdEncoding.DecodeString(r.Key)
+	if err != nil {
+		return err
+	}
+	decryptedData, err := AesECBDecrypt(r.data[HyperHeaderLength:HyperHeaderLength+r.encryptedDataLength], keyBytes)
+	if err != nil {
+		return err
+	}
+	r.decClientID = binary.LittleEndian.Uint32(decryptedData[:4]) >> 20
+	r.decExpirationDate = binary.LittleEndian.Uint32(decryptedData[:4]) & 0xFFFFF
+	r.decRandomBytesLength = int(binary.LittleEndian.Uint32(decryptedData[4:8]))
+	r.offset = HyperHeaderLength + r.encryptedDataLength + r.decRandomBytesLength
+
+	return nil
+}
+
+// parseSuperPart parses the super block containing database metadata.
+// Extracts:
+// - dbType: database format version (IPv4/IPv6)
+// - fileSize: total database size
+// - index pointers: locations of index blocks
+// Returns:
+// - error: invalid super block format
+func (r *Reader) parseSuperPart() error {
+	superPartData := r.data[r.offset : r.offset+SuperPartLength]
+	r.dbType = uint(superPartData[0])
+	r.fileSize = int(binary.LittleEndian.Uint32(superPartData[1:5]))
+	r.firstIndexPtr = int(binary.LittleEndian.Uint32(superPartData[5:9]))
+	r.totalHeaderBlockSize = int(binary.LittleEndian.Uint32(superPartData[9:13]))
+	r.lastIndexPtr = int(binary.LittleEndian.Uint32(superPartData[13:]))
+	r.setupIPVersion()
+	return nil
+}
+
+// parseHeaderBlocks processes the header blocks containing IP range index information.
+// Builds:
+// - headerIPs: list of starting IP addresses for each header block
+// - headerPtrs: corresponding index pointers
+// Returns:
+// - error: invalid header block format
+func (r *Reader) parseHeaderBlocks() error {
+	idx := 0
+	r.headerIPs = make([][]byte, r.totalHeaderBlockSize/HeaderBlockLength)
+	r.headerPtrs = make([]int, r.totalHeaderBlockSize/HeaderBlockLength)
+	for i := 0; i < r.totalHeaderBlockSize; i += HeaderBlockLength {
+		headerPtr := binary.LittleEndian.Uint32(r.data[r.offset+SuperPartLength+i+16:])
+		if headerPtr == 0 {
+			break
+		}
+		r.headerIPs[idx] = r.data[r.offset+SuperPartLength+i : r.offset+SuperPartLength+i+16]
+		r.headerPtrs[idx] = int(headerPtr)
+		idx++
+	}
+	r.headerLen = idx
+	return nil
+}
+
+func (r *Reader) loadGeoSetting() error {
+	keyBytes, err := base64.StdEncoding.DecodeString(r.Key)
+	if err != nil {
+		return err
+	}
+	r.geo.columnSelection = int(binary.LittleEndian.Uint32(r.data[r.offset+r.lastIndexPtr+r.indexBlockLength : r.offset+r.lastIndexPtr+r.indexBlockLength+4]))
+	if r.geo.columnSelection != 0 {
+		geoDataLength := int(binary.LittleEndian.Uint32(r.data[r.offset+r.lastIndexPtr+r.indexBlockLength+4 : r.offset+r.lastIndexPtr+r.indexBlockLength+8]))
+		r.geo.data = XorDecrypt(r.data[r.offset+r.lastIndexPtr+r.indexBlockLength+8:r.offset+r.lastIndexPtr+r.indexBlockLength+8+geoDataLength], keyBytes)
+	}
+	return nil
+}
+
+// setupIPVersion sets up the IP version.
+func (r *Reader) setupIPVersion() {
+	if (r.dbType & IPv6) == 0 {
+		r.ipLength = IPv4Length
+		r.indexBlockLength = IPv4IndexBlockLength
+	} else {
+		r.ipLength = IPv6Length
+		r.indexBlockLength = IPv6IndexBlockLength
+	}
+}

--- a/format/czdb/sdk/reader.go
+++ b/format/czdb/sdk/reader.go
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2024 shenjunzheng@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sdk
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"os"
+	"sync"
+
+	"github.com/sjzar/ips/ipnet"
+	"github.com/sjzar/ips/pkg/errors"
+)
+
+// Reader implements the CZDB database reader with lazy initialization and concurrent-safe access.
+// It handles both IPv4 and IPv6 database formats with AES-ECB encrypted headers.
+//
+// Usage lifecycle:
+//  1. Create instance via NewReader()
+//  2. Set decryption Key (base64 encoded)
+//  3. Call Find() for IP queries
+//  4. Close() when done (implements io.Closer)
+type Reader struct {
+	// Key contains the base64-encoded decryption key required for database access.
+	Key string
+
+	// data holds the complete database file content in memory.
+	// detail format see doc.go
+	data []byte
+
+	// --- Hyper Header ---
+	version             uint32 // format "YYYYMMDD" in decimal, e.g. 20241211
+	clientID            uint32 // client identifier
+	encryptedDataLength int    // length of encrypted data
+
+	// --- Decrypted Hyper Header ---
+	decClientID          uint32 // decrypted client identifier
+	decExpirationDate    uint32 // format is "YYMMDD" in decimal, e.g. 251216
+	decRandomBytesLength int
+
+	// --- Super Part ---
+	dbType               uint // Database type flags (bit0: 0x0=IPv4, 0x1=IPv6)
+	fileSize             int
+	firstIndexPtr        int
+	totalHeaderBlockSize int
+	lastIndexPtr         int
+
+	// --- Initialization control ---
+	inited   bool // whether the database has been inited
+	initOnce sync.Once
+	initErr  error
+
+	// offset marks the start position of the Super Part after:
+	// HyperHeader(12) + EncryptedData + RandomPadding
+	offset int
+
+	// --- Indexing parameters ---
+	ipLength         int // IP address length (4 for IPv4, 16 for IPv6)
+	indexBlockLength int // Size of each index block (13/37 bytes)
+
+	// geo handles geographical data parsing with column selection
+	geo Geo
+
+	// --- Header block cache ---
+	headerIPs  [][]byte // Starting IPs of each header block
+	headerPtrs []int    // Corresponding index pointers
+	headerLen  int      // totalHeaderBlockSize/HeaderBlockLength
+}
+
+// NewReader creates a new CZDB database reader from the specified file path.
+// It parses the hyper header information but does not decrypt the data immediately.
+// Returns:
+// - *Reader: initialized reader instance
+// - error: possible errors during file reading or header validation
+func NewReader(filePath string) (*Reader, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data) < HyperHeaderLength {
+		return nil, errors.ErrInvalidDatabase
+	}
+
+	r := &Reader{
+		data:                data,
+		version:             binary.LittleEndian.Uint32(data[:4]),
+		clientID:            binary.LittleEndian.Uint32(data[4:]),
+		encryptedDataLength: int(binary.LittleEndian.Uint32(data[8:])),
+	}
+
+	if len(data) < r.encryptedDataLength+HyperHeaderLength {
+		return nil, errors.ErrInvalidDatabase
+	}
+
+	return r, nil
+}
+
+// Init performs full initialization of the database reader including decryption and data parsing.
+// This method is called automatically on first Find() call.
+// Returns:
+// - error: possible errors during decryption or data parsing
+func (r *Reader) Init() error {
+
+	if err := r.validateKey(); err != nil {
+		return err
+	}
+	if err := r.decryptHyperHeader(); err != nil {
+		return err
+	}
+	if err := r.parseSuperPart(); err != nil {
+		return err
+	}
+	if err := r.parseHeaderBlocks(); err != nil {
+		return err
+	}
+	if err := r.loadGeoSetting(); err != nil {
+		return err
+	}
+	r.inited = true
+	return nil
+}
+
+// Find locates geographical information for the given IP address.
+// Parameters:
+// - ip: net.IP object representing the target IP address
+// Returns:
+// - *ipnet.Range: IP range containing the target IP
+// - string: geographical information in formatted string
+// - error: search failures or data parsing errors
+//
+// Note:
+// - Will automatically perform lazy initialization on first call
+// - Returned IP range bytes should not be modified
+// - Empty string return indicates no geographical data found
+func (r *Reader) Find(ip net.IP) (*ipnet.Range, string, error) {
+	if !r.inited {
+		r.initOnce.Do(func() {
+			r.initErr = r.Init()
+		})
+		if r.initErr != nil {
+			return nil, "", r.initErr
+		}
+	}
+	if r.dbType == IPv4 {
+		ip = ip.To4()
+	} else {
+		ip = ip.To16()
+	}
+
+	sptr, eptr := r.searchHeader(ip)
+	if sptr == 0 {
+		// FIXME: official database is incomplete, wait for official processing.
+		// missing 0.0.0.0/32 and [::/128] data
+		if net.IP.Equal(ip, net.IPv4zero) || net.IP.Equal(ip, net.IPv6zero) {
+			return &ipnet.Range{Start: ip, End: ip}, TempDataNotFound, nil
+		}
+		return nil, "", errors.ErrInvalidDatabase
+	}
+
+	sip, eip, dataPtr, dataLen := r.searchIndex(sptr, eptr, ip)
+	if dataPtr == 0 {
+		// FIXME: IPv6 database skip IPv4 address range
+		if r.dbType == IPv6 && net.IP.Equal(ip, net.IPv4zero) {
+			return &ipnet.Range{Start: net.IPv4zero.To16(), End: ipnet.LastIPv4.To16()}, TempDataNotFound, nil
+		}
+		return nil, "", errors.ErrInvalidDatabase
+	}
+
+	data, err := r.geo.ParseGeoInfo(r.data[r.offset+dataPtr : r.offset+dataPtr+dataLen])
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &ipnet.Range{
+		Start: sip,
+		End:   eip,
+	}, data, nil
+}
+
+// searchHeader performs binary search in header blocks to locate target index range.
+// Parameters:
+// - ip: target IP address to search for
+// Returns:
+// - sptr: start pointer of index blocks range
+// - eptr: end pointer of index blocks range
+func (r *Reader) searchHeader(ip []byte) (int, int) {
+	if r.headerLen == 0 {
+		return 0, 0
+	}
+
+	l, h := 0, r.headerLen-1
+	var sptr, eptr int
+
+	for l <= h {
+		m := (l + h) >> 1
+		cmp := bytes.Compare(ip, r.headerIPs[m])
+
+		if cmp < 0 {
+			h = m - 1
+		} else if cmp > 0 {
+			l = m + 1
+		} else {
+			if m > 0 {
+				sptr = r.headerPtrs[m-1]
+			} else {
+				sptr = r.headerPtrs[m]
+			}
+			eptr = r.headerPtrs[m]
+			break
+		}
+	}
+
+	// less than header range
+	if l == 0 && h <= 0 {
+		return 0, 0
+	}
+
+	if l > h {
+		if l < r.headerLen {
+			sptr = r.headerPtrs[l-1]
+			eptr = r.headerPtrs[l]
+		} else if h >= 0 && h+1 < r.headerLen {
+			sptr = r.headerPtrs[h]
+			eptr = r.headerPtrs[h+1]
+		} else {
+			sptr = r.headerPtrs[r.headerLen-1]
+			eptr = sptr + r.indexBlockLength
+		}
+	}
+
+	return sptr, eptr
+}
+
+// searchIndex performs binary search within index blocks to locate exact IP record.
+// Parameters:
+// - sptr: start pointer of index blocks range
+// - eptr: end pointer of index blocks range
+// - ip: target IP address
+// Returns:
+// - sip: start IP of matched range
+// - eip: end IP of matched range
+// - dataPtr: offset of geographical data
+// - dataLen: length of geographical data
+func (r *Reader) searchIndex(sptr, eptr int, ip []byte) ([]byte, []byte, int, int) {
+	l, h := 0, (eptr-sptr)/r.indexBlockLength
+
+	sip := make([]byte, r.ipLength)
+	eip := make([]byte, r.ipLength)
+	var dataPtr int
+	var dataLen int
+
+	for l <= h {
+		m := (l + h) >> 1
+		p := sptr + m*r.indexBlockLength
+
+		cmpStart := bytes.Compare(ip, r.data[r.offset+p:r.offset+p+r.ipLength])
+		cmpEnd := bytes.Compare(ip, r.data[r.offset+p+r.ipLength:r.offset+p+2*r.ipLength])
+		if cmpStart >= 0 && cmpEnd <= 0 {
+			copy(sip, r.data[r.offset+p:r.offset+p+r.ipLength])
+			copy(eip, r.data[r.offset+p+r.ipLength:r.offset+p+2*r.ipLength])
+			dataPtr = int(binary.LittleEndian.Uint32(r.data[r.offset+p+2*r.ipLength:]))
+			dataLen = int(r.data[r.offset+p+2*r.ipLength+4])
+			break
+		} else if cmpStart < 0 {
+			h = m - 1
+		} else {
+			l = m + 1
+		}
+	}
+
+	return sip, eip, dataPtr, dataLen
+}
+
+// IsIPv4 whether support ipv4
+func (r *Reader) IsIPv4() bool {
+	return r.dbType == IPv4
+}
+
+// IsIPv6 whether support ipv6
+func (r *Reader) IsIPv6() bool {
+	return r.dbType == IPv6
+}
+
+func (r *Reader) Close() error {
+	r.data = nil
+	r.headerIPs = nil
+	r.headerPtrs = nil
+	r.geo = Geo{}
+	r.inited = false
+	r.initErr = nil
+	r.initOnce = sync.Once{}
+	return nil
+}

--- a/format/reader.go
+++ b/format/reader.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/sjzar/ips/format/awdb"
+	"github.com/sjzar/ips/format/czdb"
 	"github.com/sjzar/ips/format/ip2region"
 	"github.com/sjzar/ips/format/ipdb"
 	"github.com/sjzar/ips/format/mmdb"
@@ -78,6 +79,7 @@ var (
 		plain.DBFormat:     func(file string) (Reader, error) { return plain.NewReader(file) },
 		qqwry.DBFormat:     func(file string) (Reader, error) { return qqwry.NewReader(file) },
 		zxinc.DBFormat:     func(file string) (Reader, error) { return zxinc.NewReader(file) },
+		czdb.DBFormat:      func(file string) (Reader, error) { return czdb.NewReader(file) },
 	}
 	ReaderExts = map[string]func(string) (Reader, error){
 		awdb.DBExt:      func(file string) (Reader, error) { return awdb.NewReader(file) },
@@ -87,6 +89,7 @@ var (
 		plain.DBExt:     func(file string) (Reader, error) { return plain.NewReader(file) },
 		qqwry.DBExt:     func(file string) (Reader, error) { return qqwry.NewReader(file) },
 		zxinc.DBExt:     func(file string) (Reader, error) { return zxinc.NewReader(file) },
+		czdb.DBExt:      func(file string) (Reader, error) { return czdb.NewReader(file) },
 	}
 	ReaderCommonNames = map[string]func(string) (Reader, error){}
 )

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.4
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 	golang.org/x/net v0.14.0
 	golang.org/x/text v0.12.0
 )
@@ -57,6 +58,7 @@ require (
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go4.org/netipx v0.0.0-20220812043211-3cc044ffd68d // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,10 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/ips/find.go
+++ b/internal/ips/find.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/sjzar/ips/domainlist"
 	"github.com/sjzar/ips/format"
+	"github.com/sjzar/ips/format/czdb"
 	"github.com/sjzar/ips/format/mmdb"
 	"github.com/sjzar/ips/format/qqwry"
 	"github.com/sjzar/ips/internal/data"
@@ -375,6 +376,19 @@ func (m *Manager) createDatabaseReader(_format, file string) (format.Reader, err
 		option := mmdb.ReaderOption{
 			DisableExtraData: readerOptionArg.Get("disable_extra_data") == "true",
 			UseFullField:     readerOptionArg.Get("use_full_field") == "true",
+		}
+		if err := dbr.SetOption(option); err != nil {
+			log.Debug("reader.SetOption error: ", err)
+			return nil, err
+		}
+	case *czdb.Reader:
+		readerOptionArg, err := url.ParseQuery(m.Conf.ReaderOption)
+		if err != nil {
+			log.Debug("url.ParseQuery error: ", err)
+			return nil, err
+		}
+		option := czdb.ReaderOption{
+			Key: readerOptionArg.Get("key"),
 		}
 		if err := dbr.SetOption(option); err != nil {
 			log.Debug("reader.SetOption error: ", err)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -33,6 +33,7 @@ var (
 	ErrMetaMissing            = errors.New("meta information missing")
 	ErrNilWriter              = errors.New("writer is not initialized")
 	ErrUnsupportedLanguage    = errors.New("unsupported language")
+	ErrKeyRequired            = errors.New("key is required for encrypted database, use `--database-option \"key=<your key>\"` or `--input-option \"key=<your key>\"` option to set")
 
 	// IPio
 


### PR DESCRIPTION
* 支持 `czdb` 数据库格式的查询与转储 #29
* 提供简化的 `czdb` 数据库格式 Reader SDK
	* 仅支持内存查询
	* 不处理版本、有效期等校验逻辑
	* 社区版数据库文件在 `0.0.0.0/32` 和 `[::/128]` 两处数据缺失，为了顺利转储，暂时做特殊处理，等待官方修复数据库文件

使用方式：
```shell
# 查询
ips -i cz88_public_v4.czdb --database-option "key=<your key>" 8.8.8.8

# 转储
./ips dump -i cz88_public_v4.czdb --input-option "key=<your key>"
```

感谢 @zhengjianyang 大佬的 [goCzdb](https://github.com/zhengjianyang/goCzdb) 项目，实现时有做参考

---

* Supports query and dump operations for `czdb` database format, #29
* Provides simplified `czdb` Reader SDK implementation
  * Memory-only queries
  * Excludes version validation and expiration checks
  * Community edition databases have missing data at `0.0.0.0/32` and `[::/128]`. Temporary workaround implemented for successful dumping while awaiting official database fixes.

Usage:
```shell
# Query
ips -i cz88_public_v4.czdb --database-option "key=<your key>" 8.8.8.8

# Dump
./ips dump -i cz88_public_v4.czdb --input-option "key=<your key>"
```

Special thanks to @zhengjianyang's [goCzdb](https://github.com/zhengjianyang/goCzdb) project for implementation reference.
